### PR TITLE
Unicode support and clean up

### DIFF
--- a/bin/spritz.py
+++ b/bin/spritz.py
@@ -172,7 +172,7 @@ def main():
     article = ""
     
     for line in fileinput.input(sys.argv[2:]):
-        article += line
+        article += to_unicode(line)
     reading = parse_article(article)
     spritz(wpm, reading)
 

--- a/bin/spritz.py
+++ b/bin/spritz.py
@@ -1,88 +1,169 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
+from __future__ import print_function, unicode_literals
+
 import sys
-import fileinput
 import time
 import math
+import fileinput
 
-def ORP(n):
+def to_unicode(text, encoding='utf-8'):
+    """Convert ``text`` to unicode using ``encoding``.
+
+    :param text: string object to convert to ``unicode``
+    :type text: ``str`` or ``unicode``
+    :returns: string object as unicode object
+    :rytpe: ``unicode``
+    """
+    if isinstance(text, basestring):
+        if not isinstance(text, unicode):
+            text = unicode(text, encoding)
+    return text
+
+##################################################
+#   ORP Functions                                #
+##################################################
+
+def get_orp(integer):
+    """Get Optimal Reading Position (ORP) given ``integer``.
+    ORP is slightly left of center.
+
+    :param integer: length of string object to calculate ORP
+    :type integer: ``integer``
+    :returns: value of ORP
+    :rytpe: ``integer``
+    """
     percentage = 0.45
-    return int(math.ceil(n * 0.45))
+    return int(math.ceil(integer * percentage))
 
-def calculate_spaces(word, maxLength):
-    maxOrp = ORP(maxLength) # index + 1
-    orp = ORP(len(word)) # index + 1
-    prefixSpace = maxOrp - orp
-    postfixSpace = maxLength - len(word) - prefixSpace
+def calculate_spaces(word, max_length):
+    """Determine buffer spaces for ``word`` given the ``max_length``.
+
+    :param word: string object for calculation
+    :type word: ``unicode``
+    :param max_length: value of longest word in full text
+    :type max_length: ``integer``
+    :returns: word's ORP, number of prefix spaces, and number of post spaces
+    :rytpe: ``tuple`` of ``integers``
+    """
+    max_orp = get_orp(max_length)
+    orp = get_orp(len(word))
+    prefix_space = (max_orp - orp)
+    postfix_space = (max_length - len(word) - prefix_space)
     
-    return (orp, prefixSpace, postfixSpace)
+    return (orp, prefix_space, postfix_space)
 
 def find_max(reading):
-    reading = sorted(reading, key=lambda x: len(x), reverse=True)
+    """
+    Find longest word in ``reading``.
+
+    :param reading: the full string object to be spritzed
+    :type reading: ``unicode``
+    :returns: number of characters in the longest word
+    :rytpe: ``integer``
+    """
+    reading = sorted(reading, key=len, reverse=True)
     return len(reading[0])
+
+##################################################
+#   Output Functions                             #
+##################################################
+
+def insert_color(word, orp):
+    """Change color of the ORP letter in ``word`` to red.
+
+    :param word: the word to be color-coded
+    :type word: ``unicode``
+    :param orp: the index of the ORP letter
+    :type orp: ``integer``
+    :returns: word with ORP letter in red
+    :rytpe: ``unicode``
+    """
+    color_red = "\033[91m"
+    color_restore = "\033[0m"
+
+    chars = list(word)
+    chars.insert(orp, color_red)
+    chars.insert((orp + 2), color_restore)
+    return ''.join(chars)
+
+def print_word(word, orp_config):
+    """Pretty print `word` with spritz color formatting
+
+    :param word: the word to be color-coded
+    :type word: ``unicode``
+    :param orp_config: formatting data for ``word``
+    :type orp_config: ``tuple`` of ``integers``
+    :returns: Nothing. Prints to console
+    :rytpe: ``None``
+    """
+    (orp, prefix, postfix) = orp_config
+    orp = orp - 1           # change for Python list indexing
+    print_string = (" " * prefix) + insert_color(word, orp) + (" " * postfix)
+
+    print("\r{}".format(print_string))
+    sys.stdout.flush()
+
+##################################################
+#   Key Functions                                #
+##################################################
 
 def parse_article(article):
     """
-    argument: article::string
-    returns: [ word::string | sign::string ]
-
-    word :: single word
-    sign :: <pause>
+    Clean up input ``article`` and insert appropriate pauses.
+    
+    :param article: the full string object to be spritzed
+    :type article: ``unicode``
+    :returns: words in ``article``
+    :rytpe: ``list``
     """
-    charToRemoved = ",.!\xad"
+    remove = (',', '.', '!', '?', '-', ';')
 
-    for eachChar in charToRemoved:
-        article = article.replace(eachChar, "")
+    for char in remove:
+        article = article.replace(char, " <pause> ")
 
     article = article.strip()
-    article = article.replace("\n", " <pause> ")
+    article = article.replace("\n", " <pause> <pause> ")
 
     return article.split()
 
-def print_word(word, orpConfig):
-    def insert_color(word, orpIndex):
-        colorCode_red = "\033[91m"
-        colorCode_restore = "\033[0m"
-
-        return word[0:orpIndex] + colorCode_red + word[orpIndex] + colorCode_restore + word[orpIndex+1:]
-        
-    orp, prefix, postfix = orpConfig
-    stringToPrint = " " * prefix + insert_color(word, orp-1) + " " * postfix
-
-    print ("\r%s" % stringToPrint, end='')
-    sys.stdout.flush()
-
 def spritz(wpm, reading):
+    """"Spritz" the ``reading``.
+
+    :param wpm: words per minute
+    :type wpm: ``integer``
+    :param reading: the full string object to be spritzed
+    :type reading: ``unicode``
+    :returns: Nothing. Prints to console
+    :rytpe: ``None``
     """
-    function to perform "spritz"
-    """
-    secondPerWord = 60.0 / wpm
-    sleepInterval = secondPerWord 
-    maxLength = find_max(reading)
+    sleep_interval = (60.0 / wpm)
+    max_length = find_max(reading)
 
     for word in reading:
         if word == "<pause>":
-            time.sleep(sleepInterval * 10)
+            time.sleep(sleep_interval * 3)
             continue
 
-        wordSleepInterval = 0.01 * len(word)
+        word_sleep_interval = 0.01 * len(word)
 
-        time.sleep(sleepInterval + wordSleepInterval)
-        orpConfig = calculate_spaces(word, maxLength)
-        print_word(word, orpConfig)
+        time.sleep(sleep_interval + word_sleep_interval)
+        orp_config = calculate_spaces(word, max_length)
+        #print(word)
+        print_word(word, orp_config)
 
-def main(wpm, article):
+##################################################
+#   Main Function                                #
+##################################################
+
+def main():
+    """Parse command line args and spritz text.
     """
-    Main function
-    """
-    reading = parse_article(article)
-    spritz(wpm, reading)
-
-if __name__ == '__main__':
     if len(sys.argv) >= 2 and sys.argv[1]:
         try:
             wpm = int(sys.argv[1])
-        except:
+        except ValueError:
             print ("<wpm> need to be an integer")
             exit(1)
     else:
@@ -92,5 +173,8 @@ if __name__ == '__main__':
     
     for line in fileinput.input(sys.argv[2:]):
         article += line
-    
-    main(wpm, article)
+    reading = parse_article(article)
+    spritz(wpm, reading)
+
+if __name__ == '__main__':
+    main()

--- a/bin/spritz.py
+++ b/bin/spritz.py
@@ -8,6 +8,7 @@ import time
 import math
 import fileinput
 
+
 def to_unicode(text, encoding='utf-8'):
     """Convert ``text`` to unicode using ``encoding``.
 
@@ -69,7 +70,7 @@ def find_max(reading):
 #   Output Functions                             #
 ##################################################
 
-def insert_color(word, orp):
+def color_orp_char(word, orp):
     """Change color of the ORP letter in ``word`` to red.
 
     :param word: the word to be color-coded
@@ -80,7 +81,7 @@ def insert_color(word, orp):
     :rytpe: ``unicode``
     """
     color_red = '\x1b[91m'
-    color_restore = '\x1b[0m'    
+    color_restore = '\x1b[0m'
     chars = list(word)
     chars.insert(orp, color_red)
     chars.insert((orp + 2), color_restore)
@@ -98,13 +99,13 @@ def print_word(word, orp_config):
     """
     (orp, prefix, postfix) = orp_config
     orp = orp - 1           # change for Python list indexing
-    print_string = (" " * prefix) + insert_color(word, orp) + (" " * postfix)
+    print_string = (" " * prefix) + color_orp_char(word, orp) + (" " * postfix)
 
     print("\r{}".format(print_string))
     sys.stdout.flush()
 
 ##################################################
-#   Key Functions                                #
+#   Clean-Up Functions                           #
 ##################################################
 
 def parse_article(article):
@@ -125,6 +126,10 @@ def parse_article(article):
 
     return article.split()
 
+##################################################
+#   Spritz Function                              #
+##################################################
+
 def spritz(wpm, reading):
     """"Spritz" the ``reading``.
 
@@ -136,6 +141,8 @@ def spritz(wpm, reading):
     :rytpe: ``None``
     """
     sleep_interval = (60.0 / wpm)
+    
+    reading = parse_article(reading)
     max_length = find_max(reading)
 
     for word in reading:
@@ -147,7 +154,6 @@ def spritz(wpm, reading):
 
         time.sleep(sleep_interval + word_sleep_interval)
         orp_config = calculate_spaces(word, max_length)
-        #print(word)
         print_word(word, orp_config)
 
 ##################################################
@@ -170,8 +176,9 @@ def main():
     
     for line in fileinput.input(sys.argv[2:]):
         article += to_unicode(line)
-    reading = parse_article(article)
-    spritz(wpm, reading)
+    
+    spritz(wpm, article)
+
 
 if __name__ == '__main__':
     main()

--- a/bin/spritz.py
+++ b/bin/spritz.py
@@ -55,8 +55,7 @@ def calculate_spaces(word, max_length):
     return (orp, prefix_space, postfix_space)
 
 def find_max(reading):
-    """
-    Find longest word in ``reading``.
+    """Find longest word in ``reading``.
 
     :param reading: the full string object to be spritzed
     :type reading: ``unicode``
@@ -110,8 +109,7 @@ def print_word(word, orp_config):
 ##################################################
 
 def parse_article(article):
-    """
-    Clean up input ``article`` and insert appropriate pauses.
+    """Clean up input ``article`` and insert appropriate pauses.
     
     :param article: the full string object to be spritzed
     :type article: ``unicode``

--- a/bin/spritz.py
+++ b/bin/spritz.py
@@ -79,16 +79,15 @@ def insert_color(word, orp):
     :returns: word with ORP letter in red
     :rytpe: ``unicode``
     """
-    color_red = "\033[91m"
-    color_restore = "\033[0m"
-
+    color_red = '\x1b[91m'
+    color_restore = '\x1b[0m'    
     chars = list(word)
     chars.insert(orp, color_red)
     chars.insert((orp + 2), color_restore)
     return ''.join(chars)
 
 def print_word(word, orp_config):
-    """Pretty print `word` with spritz color formatting
+    """Pretty print ``word`` with spritz color formatting
 
     :param word: the word to be color-coded
     :type word: ``unicode``

--- a/bin/spritz.py
+++ b/bin/spritz.py
@@ -35,8 +35,12 @@ def get_orp(integer):
     :returns: value of ORP
     :rytpe: ``integer``
     """
-    percentage = 0.45
-    return int(math.ceil(integer * percentage))
+    percentage = 0.35
+    orp = int(math.ceil(integer * percentage))
+    if orp > 5:
+        return 5
+    else:
+        return orp
 
 def calculate_spaces(word, max_length):
     """Determine buffer spaces for ``word`` given the ``max_length``.
@@ -49,7 +53,10 @@ def calculate_spaces(word, max_length):
     :rytpe: ``tuple`` of ``integers``
     """
     max_orp = get_orp(max_length)
-    orp = get_orp(len(word))
+    if len(word) < 3:
+        orp = len(word)
+    else:
+        orp = get_orp(len(word))
     prefix_space = (max_orp - orp)
     postfix_space = (max_length - len(word) - prefix_space)
     

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ from distutils.core import setup
 setup(
     name='spritz',
     version='0.1',
-    author='Colin Su',
-    author_email='littleq0903@gmail.com',
+    authors=['Colin Su', 'Stephen Margheim'], 
+    author_emails=['littleq0903@gmail.com', 'stephen.margheim@gmail.com'],
     scripts=['bin/spritz.py'],
     license='LICENSE',
     description='Command-line version of Spritz',


### PR DESCRIPTION
I've made a number of cosmetic changes along with explicit support for Unicode input. The cosmetic changes make `spritz.py` fully compliant with PEP8 standards (as tested by `pylinter`) and offers better documentation. I've also opted for more "Pythonic" methods in a few places (concatenating strings via the str -> list -> str method, etc). I've also altered the behavior around punctuation. Full- and half-stop punctuation is replaced with a single `<pause>`, while newlines are replaced with two. Then, I've shortened the pause time to 3x the seconds per word.

Other than all of the cosmetic changes tho, it works from the command line exactly as before (but with Unicode support).